### PR TITLE
Add condition for Sev1 alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ module "azurerm_logic_app_workflow" {
 | [azurerm_logic_app_action_custom.condition_check_for_waf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.var_affected_resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_action_custom.var_alarm_context](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.var_alarm_severity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
+| [azurerm_logic_app_action_custom.var_signal_type](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_action_custom) | resource |
 | [azurerm_logic_app_trigger_http_request.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_trigger_http_request) | resource |
 | [azurerm_logic_app_workflow.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_workflow) | resource |
 | [azurerm_management_lock.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) | resource |
@@ -81,7 +83,7 @@ module "azurerm_logic_app_workflow" {
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Conditionally launch resources into an existing resource group. Specifying this will NOT create a resource group. | `string` | `""` | no |
 | <a name="input_log_analytics_retention_period_days"></a> [log\_analytics\_retention\_period\_days](#input\_log\_analytics\_retention\_period\_days) | Retention period for logs in the Log Analyitcs Workspace. Has no effect if you are using an existing workspace | `number` | `30` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
-| <a name="input_resource_group_target_webhooks"></a> [resource\_group\_target\_webhooks](#input\_resource\_group\_target\_webhooks) | Slack webhook destinations keyed by the Resource Group you want to collect webhooks from | <pre>map(<br>    object({<br>      webhook_url = string<br>      channel_id  = string<br>    })<br>  )</pre> | `{}` | no |
+| <a name="input_resource_group_target_webhooks"></a> [resource\_group\_target\_webhooks](#input\_resource\_group\_target\_webhooks) | Slack webhook destinations keyed by the Resource Group you want to collect webhooks from | <pre>map(<br>    object({<br>      webhook_url      = string<br>      channel_id       = string<br>      sev1_channel_id  = optional(string, "")<br>      sev1_webhook_url = optional(string, "")<br>    })<br>  )</pre> | `{}` | no |
 | <a name="input_route_waf_logs"></a> [route\_waf\_logs](#input\_route\_waf\_logs) | Do you want to route WAF Logs to a separate Slack channel? | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |
 | <a name="input_waf_logs_channel_id"></a> [waf\_logs\_channel\_id](#input\_waf\_logs\_channel\_id) | Slack webhook destination channel ID for WAF Logs | `string` | `""` | no |

--- a/logic-app.tf
+++ b/logic-app.tf
@@ -7,25 +7,44 @@ resource "azurerm_logic_app_workflow" "default" {
 }
 
 resource "azurerm_logic_app_trigger_http_request" "default" {
-  name         = "${local.resource_prefix}-trigger"
+  name         = "http-request-trigger"
   logic_app_id = azurerm_logic_app_workflow.default.id
   schema       = local.trigger_alert_schema
 }
 
 resource "azurerm_logic_app_action_custom" "var_affected_resource" {
-  name         = "${local.resource_prefix}-setvars0"
+  name         = "var-affected-resource"
   logic_app_id = azurerm_logic_app_workflow.default.id
   body         = local.var_affected_resource
 }
 
 resource "azurerm_logic_app_action_custom" "var_alarm_context" {
-  name         = "${local.resource_prefix}-setvars1"
+  name         = "var-alarm-context"
   logic_app_id = azurerm_logic_app_workflow.default.id
   body         = local.var_alarm_context
 }
 
+resource "azurerm_logic_app_action_custom" "var_alarm_severity" {
+  name         = "var-alarm-severity"
+  logic_app_id = azurerm_logic_app_workflow.default.id
+  body         = local.var_alarm_severity
+}
+
+resource "azurerm_logic_app_action_custom" "var_signal_type" {
+  name         = "var-signal-type"
+  logic_app_id = azurerm_logic_app_workflow.default.id
+  body         = local.var_signal_type
+}
+
 resource "azurerm_logic_app_action_custom" "condition_check_for_waf" {
-  name         = "${local.resource_prefix}-condition"
+  name         = "condition-waf-resource-group"
   logic_app_id = azurerm_logic_app_workflow.default.id
   body         = local.waf_condition
+
+  depends_on = [
+    azurerm_logic_app_action_custom.var_affected_resource,
+    azurerm_logic_app_action_custom.var_alarm_context,
+    azurerm_logic_app_action_custom.var_alarm_severity,
+    azurerm_logic_app_action_custom.var_signal_type
+  ]
 }

--- a/templates/actions/condition.json.tpl
+++ b/templates/actions/condition.json.tpl
@@ -1,11 +1,11 @@
 {
-  "description": "Compare two values in an expression and execute an action based on the result",
+  "description": "${description}",
   "actions": {
-    %{ if action_if_true != "{}" ~} "${name}-action-true" : ${action_if_true} %{ endif ~}
+    %{ if action_if_true != "{}" ~} "${name}.action.true" : ${action_if_true} %{ endif ~}
   },
   "else": {
     "actions": {
-      %{ if action_if_false != "{}" ~} "${name}-action-false" : ${action_if_false} %{ endif ~}
+      %{ if action_if_false != "{}" ~} "${name}.action.false" : ${action_if_false} %{ endif ~}
     }
   },
   "runAfter": ${run_after},

--- a/templates/actions/http.json.tpl
+++ b/templates/actions/http.json.tpl
@@ -1,5 +1,5 @@
 {
-  "description": "Send a HTTP Request",
+  "description": "${description}",
   "type": "Http",
   "inputs": {
     "uri": "${uri}",

--- a/templates/actions/switch.json.tpl
+++ b/templates/actions/switch.json.tpl
@@ -1,11 +1,11 @@
 {
-  "description": "Conditionally run a subsequent action based on an expression",
+  "description": "${description}",
   "cases": {
     %{ if length(cases) > 0 ~}
       %{ for key, case in cases ~}
-        "${key}-case": {
+        "${key}.case": {
           "actions": {
-            "${key}-action": ${case.action}
+            "${key}.action": ${case.action}
           },
           "case": "${key}"
         },

--- a/templates/variables/severity.json.tpl
+++ b/templates/variables/severity.json.tpl
@@ -1,0 +1,16 @@
+{
+  "description": "Alarm Severity",
+  "inputs": {
+    "variables": [{
+      "name": "alarmSeverity",
+      "type": "string",
+      "value": "@triggerBody()?['data']?['essentials']?['severity']"
+    }]
+  },
+  "runAfter": {
+    "${run_after}": [
+      "Succeeded"
+    ]
+  },
+  "type": "InitializeVariable"
+}

--- a/templates/variables/signal-type.json.tpl
+++ b/templates/variables/signal-type.json.tpl
@@ -1,0 +1,16 @@
+{
+  "description": "Signal Type",
+  "inputs": {
+    "variables": [{
+      "name": "signalType",
+      "type": "string",
+      "value": "@triggerBody()?['data']?['essentials']?['signalType']"
+    }]
+  },
+  "runAfter": {
+    "${run_after}": [
+      "Succeeded"
+    ]
+  },
+  "type": "InitializeVariable"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,8 +53,10 @@ variable "resource_group_target_webhooks" {
   description = "Slack webhook destinations keyed by the Resource Group you want to collect webhooks from"
   type = map(
     object({
-      webhook_url = string
-      channel_id  = string
+      webhook_url      = string
+      channel_id       = string
+      sev1_channel_id  = optional(string, "")
+      sev1_webhook_url = optional(string, "")
     })
   )
   default = {}


### PR DESCRIPTION
This pull request adds an extra conditional step into the Workflow to determine what the severity of the alarm is. If the value is 'Sev1', and an operator has defined a specific 'sev1_channel_id' and 'sev1_webhook_url' the alarm will be routed to that endpoint instead.

Note that when using Slack Webhooks, the webhook URL is scoped to a single channel only. This is why we must specify both values.